### PR TITLE
fix(qa): fix docker-compose.qa.yml

### DIFF
--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -46,7 +46,6 @@ services:
     depends_on:
       - service-registry
       - service-gateway
-      - project-service-db
       - rabbitmq
       - zipkin
 
@@ -62,7 +61,6 @@ services:
     depends_on:
       - service-registry
       - service-gateway
-      - task-service-db
       - rabbitmq
       - zipkin
 


### PR DESCRIPTION
remove redundant dependency on project-service-db and task-service-db

BREAKING CHANGE: remove redundant dependency on project-service-db and task-service-db

fix #33